### PR TITLE
画像の保存先をlocalへ変更

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,8 +28,9 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  #↓S3保存をオリジナルアプリに変更した為、localに変更
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,8 +35,9 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
+  #↓S3保存をオリジナルアプリに変更した為、localに変更
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,12 +6,14 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-amazon:
-  service: S3
-  region: ap-northeast-1
-  bucket: furima32353
-  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
-  secret_access_key:  <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+# ↓S3保存をオリジナルアプリに変更した為、コメントアウト
+# amazon:
+#   service: S3
+#   region: ap-northeast-1
+#   bucket: furima32353
+#   access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+#   secret_access_key:  <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+# ↑S3保存をオリジナルアプリに変更した為、コメントアウト
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
#What
画像の保存先をlocalへ変更
#Why
S3を利用した画像保存をオリジナルアプリで行う為、フリマアプリの画像保存先をlocalへ変更